### PR TITLE
Link issues to scans

### DIFF
--- a/schemas/vulnapi/draft/2024-10/issue-report.schema.json
+++ b/schemas/vulnapi/draft/2024-10/issue-report.schema.json
@@ -7,7 +7,6 @@
     "required": [
         "id",
         "name",
-        "url",
         "cvss",
         "status"
     ],
@@ -60,6 +59,28 @@
                 "passed",
                 "failed"
             ]
+        },
+        "scans": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "status"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "passed",
+                            "failed"
+                        ]
+                    }
+                }
+            }
         }
     }
 }

--- a/schemas/vulnapi/draft/2024-10/scan-report.schema.json
+++ b/schemas/vulnapi/draft/2024-10/scan-report.schema.json
@@ -4,15 +4,22 @@
     "title": "Scan Report",
     "description": "",
     "type": "object",
-    "required": [],
+    "required": ["id"],
     "properties": {
+        "id": {
+            "type": "string"
+        },
         "request": {
             "type": "object",
             "required": [
+                "id",
                 "method",
                 "url"
             ],
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "method": {
                     "type": "string"
                 },

--- a/schemas/vulnapi/draft/2024-10/security-scheme-report.schema.json
+++ b/schemas/vulnapi/draft/2024-10/security-scheme-report.schema.json
@@ -41,7 +41,7 @@
                 "cookie"
             ]
         },
-        "token_format": {
+        "tokenFormat": {
             "type": "string",
             "enum": [
                 "jwt",


### PR DESCRIPTION
New properties are added in order to link each issues to related scans performed. This should help investigating and reproducing when scan failed:

* Scan ID
* Issues Scans with Scan ID and status for each issue